### PR TITLE
Grey shade error resolved

### DIFF
--- a/lib/widgets/custom_card_widget.dart
+++ b/lib/widgets/custom_card_widget.dart
@@ -118,8 +118,10 @@ class CustomCardWidget extends StatelessWidget {
                                   SizedBox(
                                     height: height * .01,
                                   ),
-                                  Center(
-                                      child: Flexible(
+                                  Flex(
+                                    direction: Axis.horizontal,
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                      children:[ Flexible(
                                           child: InkWell(
                                               onTap: () {
                                                 openLink(_project.link);
@@ -134,7 +136,7 @@ class CustomCardWidget extends StatelessWidget {
                                                               TextDecoration
                                                                   .underline,
                                                           color:
-                                                              kAccentColorLight))))),
+                                                              kAccentColorLight))))]),
                                 ],
                               ),
                             if (_project.smallIcons != null)


### PR DESCRIPTION
The issue was: 'Flexible' widget couldn not be the child of 'Center' Widget. Had to fix it using Flex and it's attributes. 